### PR TITLE
fixes #1 error handling for no such file or directory

### DIFF
--- a/src/god/god.go
+++ b/src/god/god.go
@@ -7,7 +7,12 @@ import (
 )
 
 func main() {
-	gopath, _ := filepath.Abs(filepath.Dir(os.Args[0]))
+	gopath, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		os.Stderr.WriteString(err.Error() + "\n")
+		os.Exit(1)
+	}
+
 	os.Setenv("GOPATH", gopath)
 	cmd := exec.Command("go", os.Args[1:]...)
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
Test:

```
$ go build god.go
$ mkdir -p test
$ cd test/
$ rmdir ../test
$ ../god
getwd: no such file or directory
```
